### PR TITLE
Fix MSVS 2013 warning about a condition being always true.

### DIFF
--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -38,7 +38,7 @@ inline ThreadPool::ThreadPool(size_t threads)
         workers.emplace_back(
             [this]
             {
-                while(true)
+                for(;;)
                 {
                     std::unique_lock<std::mutex> lock(this->queue_mutex);
                     while(!this->stop && this->tasks.empty())


### PR DESCRIPTION
Use "for(;;)" for the infinite loop to avoid the warning at /W4 warning level.
