### PR TITLE
Set max size of the queue.

### DIFF
--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -10,7 +10,7 @@
 #include <future>
 #include <functional>
 #include <stdexcept>
-#include <iostream>
+
 class semaphore{
   private:
     std::mutex mtx;


### PR DESCRIPTION
Using semaphore to set the max size of the task queue to avoid the size of task queue growing infinitely.
Once the size of queue reach the limit, the enqueue function will be blocked.
