### PR TITLE
Semantic/format and queue emplace improvement.

### DIFF
--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -11,31 +11,32 @@
 #include <functional>
 #include <stdexcept>
 
-class ThreadPool {
+class ThreadPool
+{
 public:
     ThreadPool(size_t);
     template<class F, class... Args>
-    auto enqueue(F&& f, Args&&... args) 
+    auto enqueue(F&& f, Args&&... args)
         -> std::future<typename std::result_of<F(Args...)>::type>;
-    ~ThreadPool();
+    ~ThreadPool(void);
 private:
     // need to keep track of threads so we can join them
     std::vector< std::thread > workers;
     // the task queue
-    std::queue< std::function<void()> > tasks;
-    
+    std::queue< std::function<void(void)> > tasks;
+
     // synchronization
     std::mutex queue_mutex;
     std::condition_variable condition;
     bool stop;
 };
- 
+
 // the constructor just launches some amount of workers
-inline ThreadPool::ThreadPool(size_t threads)
+inline ThreadPool::ThreadPool(const size_t threads)
     :   stop(false)
 {
     for(size_t i = 0;i<threads;++i)
-        workers.emplace_back(
+        this->workers.emplace_back(
             [this]
             {
                 for(;;)
@@ -45,7 +46,7 @@ inline ThreadPool::ThreadPool(size_t threads)
                         this->condition.wait(lock);
                     if(this->stop && this->tasks.empty())
                         return;
-                    std::function<void()> task(this->tasks.front());
+                    std::function<void(void)> task(this->tasks.front());
                     this->tasks.pop();
                     lock.unlock();
                     task();
@@ -56,38 +57,38 @@ inline ThreadPool::ThreadPool(size_t threads)
 
 // add new work item to the pool
 template<class F, class... Args>
-auto ThreadPool::enqueue(F&& f, Args&&... args) 
+auto ThreadPool::enqueue(F&& f, Args&&... args)
     -> std::future<typename std::result_of<F(Args...)>::type>
 {
-    typedef typename std::result_of<F(Args...)>::type return_type;
-    
+    using return_type = typename std::result_of<F(Args...)>::type;
+
     // don't allow enqueueing after stopping the pool
-    if(stop)
+    if(this->stop)
         throw std::runtime_error("enqueue on stopped ThreadPool");
 
-    auto task = std::make_shared< std::packaged_task<return_type()> >(
+    auto task = std::make_shared< std::packaged_task<return_type(void)> >(
             std::bind(std::forward<F>(f), std::forward<Args>(args)...)
         );
-        
+
     std::future<return_type> res = task->get_future();
     {
-        std::unique_lock<std::mutex> lock(queue_mutex);
-        tasks.push([task](){ (*task)(); });
+        std::unique_lock<std::mutex> lock(this->queue_mutex);
+        this->tasks.emplace([task](void){ (*task)(); });
     }
-    condition.notify_one();
+    this->condition.notify_one();
     return res;
 }
 
 // the destructor joins all threads
-inline ThreadPool::~ThreadPool()
+inline ThreadPool::~ThreadPool(void)
 {
     {
-        std::unique_lock<std::mutex> lock(queue_mutex);
-        stop = true;
+        std::unique_lock<std::mutex> lock(this->queue_mutex);
+        this->stop = true;
     }
     condition.notify_all();
-    for(size_t i = 0;i<workers.size();++i)
-        workers[i].join();
+    for(size_t i = 0;i<this->workers.size();++i)
+        this->workers[i].join();
 }
 
 #endif


### PR DESCRIPTION
I'm purposing a semantic/format fix to fix some inconsistency where some parts of the code would refer to the members via "this->" and others reference the member variables directly. I've changed all to "this->mem" format. Some brackets are moved to be more consistent over all. I've also added void to signatures for readability. I realise this is just personally preference and you might not like it, so it's okay to not accept this.

I've also changed push to emplace in the enqueue method. Since we are constructing a std::function with a lambda, I think emplace makes sense here.

I also think it would be appropriate to have a default constructor as below:

> ThreadPool(void)
> : ThreadPool(std::thread::hardware_concurrency() > 0
> ? std::thread::hardware_concurrency() : 2) {}

It would look better if we have a static local function

> static size_t getDefaultThreadPoolSize(void)
> {
>     const auto size = std::thread::hardware_concurrency();
>     return size > 0 ? size : 2; // or another suitable number.
> }

then we can have:

> ThreadPool(void) : ThreadPool(getDefaultThreadPoolSize()) {}

Let me know what you think.
