### PR TITLE
Exit policy of pool is now configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A simple C++11 Thread Pool implementation.
 
 Basic usage:
 ```c++
-// create thread pool with 4 worker threads
-ThreadPool pool(4);
+// create thread pool with 4 worker threads with the option to drain the task queue before exit
+ThreadPool pool(4, true);
 
 // enqueue and store future
 auto result = pool.enqueue([](int answer) { return answer; }, 42);

--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -29,10 +29,13 @@ private:
     std::mutex queue_mutex;
     std::condition_variable condition;
     bool stop;
+    
+    //exit policy
     bool immediateExit;
 };
 
-// the constructor just launches some amount of workers
+//threads - number of threads to start
+//immediateExit - when destructor is called, if immediateExit is true, the remaining pending tasks are discarded
 inline ThreadPool::ThreadPool(size_t threads, bool immediateExit)
 : stop(false),
 immediateExit(immediateExit)

--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -14,9 +14,9 @@
 class ThreadPool {
     using Task = std::function<void()>;
 public:
-    ThreadPool(size_t);
+    ThreadPool(size_t threads, bool immediateExit);
     template<class F, class... Args>
-    auto enqueue(F&& f, Args&&... args) 
+    auto enqueue(F&& f, Args&&... args)
         -> std::future<typename std::result_of<F(Args...)>::type>;
     ~ThreadPool();
 private:
@@ -29,55 +29,56 @@ private:
     std::mutex queue_mutex;
     std::condition_variable condition;
     bool stop;
+    bool immediateExit;
 };
- 
+
 // the constructor just launches some amount of workers
-inline ThreadPool::ThreadPool(size_t threads)
-    :   stop(false)
+inline ThreadPool::ThreadPool(size_t threads, bool immediateExit)
+: stop(false),
+immediateExit(immediateExit)
 {
     for(size_t i = 0;i<threads;++i)
         workers.emplace_back(
-            [this]
-            {
-                for(;;)
-                {
-                    Task task;
-
-                    {
-                        std::unique_lock<std::mutex> lock(this->queue_mutex);
-                        this->condition.wait(lock,
-                            [this]{ return this->stop || !this->tasks.empty(); });
-                        if(this->stop)
-                            return;
-                        task = std::move(this->tasks.front());
-                        this->tasks.pop();
-                    }
-
-                    task();
-                }
-            }
-        );
+                             [this]
+                             {
+                                 for(;;)
+                                 {
+                                     Task task;
+                                     
+                                     {
+                                         std::unique_lock<std::mutex> lock(this->queue_mutex);
+                                         this->condition.wait(lock,
+                                                              [this]{ return this->stop || !this->tasks.empty(); });
+                                         bool dontDrain = this->immediateExit ? true : this->tasks.empty();
+                                         if(this->stop && dontDrain)
+                                             return;
+                                         task = std::move(this->tasks.front());
+                                         this->tasks.pop();
+                                     }
+                                     
+                                     task();
+                                 }
+                             }
+                             );
 }
 
 // add new work item to the pool
 template<class F, class... Args>
-auto ThreadPool::enqueue(F&& f, Args&&... args) 
+auto ThreadPool::enqueue(F&& f, Args&&... args)
     -> std::future<typename std::result_of<F(Args...)>::type>
 {
     using return_type = typename std::result_of<F(Args...)>::type;
-
-    auto task = std::make_shared< std::packaged_task<return_type()> >(
-            std::bind(std::forward<F>(f), std::forward<Args>(args)...)
-        );
-        
+    
+    auto task = std::make_shared< std::packaged_task<return_type()> >(std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+    
     auto res = task->get_future();
     {
         std::unique_lock<std::mutex> lock(queue_mutex);
-
+        
         // don't allow enqueueing after stopping the pool
         if(stop)
             throw std::runtime_error("enqueue on stopped ThreadPool");
-
+        
         tasks.emplace([task](){ (*task)(); });
     }
     condition.notify_one();

--- a/example.cpp
+++ b/example.cpp
@@ -9,7 +9,7 @@ int main()
     std::future<int> last;
     {
         // the pool will discard pending tasks when exiting
-        ThreadPool pool(2, true);
+        ThreadPool pool(2, false);
         
         auto task1 = []() -> int
         {
@@ -39,7 +39,7 @@ int main()
     
     try
     {
-        //when immediate exit is true, future throws an exception if task was not completed
+        //when drain is false, future throws an exception if task was not completed
         std::cout << "===" << last.get() << "===" << std::endl;
     }
     catch( std::exception& e)

--- a/example.cpp
+++ b/example.cpp
@@ -6,9 +6,9 @@
 int main()
 {
     
-    std::future<int> last;
+    std::future<int> first, second, last;
     {
-        // the pool will discard pending tasks when exiting
+        // the pool will execute all pending tasks before exiting
         ThreadPool pool(2, false);
         
         auto task1 = []() -> int
@@ -32,14 +32,19 @@ int main()
             return 3;
         };
         
-        pool.enqueue(task1);
-        pool.enqueue(task2);
+        first = pool.enqueue(task1);
+        second = pool.enqueue(task2);
         last = pool.enqueue(task3);
+        
+        // The pool will destroy immediately after queueing tasks, so there is no gurantee which tasks will get to run on the threads, when drain is set to FALSE.
+        // Use this sleep to delay this. Ugly, but effective for demo purposes
+        // std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
     
     try
     {
-        //when drain is false, future throws an exception if task was not completed
+        std::cout << "===" << first.get() << "===" << std::endl;
+        std::cout << "===" << second.get() << "===" << std::endl;
         std::cout << "===" << last.get() << "===" << std::endl;
     }
     catch( std::exception& e)

--- a/example.cpp
+++ b/example.cpp
@@ -9,7 +9,7 @@ int main()
     std::future<int> first, second, last;
     {
         // the pool will execute all pending tasks before exiting
-        ThreadPool pool(2, false);
+        ThreadPool pool(2, true);
         
         auto task1 = []() -> int
         {


### PR DESCRIPTION
When the pool must exit, the option of draining the task queue or not is configurable.
Updated readme and example to reflect this.
