### PR TITLE
avoid pending when stop worker thread

### DIFF
--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -41,6 +41,12 @@ inline ThreadPool::ThreadPool(size_t threads)
                 for(;;)
                 {
                     std::function<void()> task;
+                    
+                    // !!! condition notify_all() may lost, then worker thread will hang on condtion.wait
+                    // suppose worker is execute here, meanwhile the pool instance is destructing: set stop = true and execute condition.notify_all();
+                    // if here lacks check stop, this worker will hang on condtion.wait() because notify is lost
+                    if (this->stop)
+                        return;
 
                     {
                         std::unique_lock<std::mutex> lock(this->queue_mutex);


### PR DESCRIPTION
# Under given conditions, worker thread may be suspended

 The main thread destruct pool instance:

``` c++
    {
        std::unique_lock<std::mutex> lock(queue_mutex);
        stop = true;
    }
    condition.notify_all();
```

In worker thread, insert a statement to sleep make the problem happen:

``` c++
      std::function<void()> task;

       {
                // sleep 1 second, let main thread destruct pool first
                std::this_thread::sleep_for(std::chrono::seconds(1));

                std::unique_lock<std::mutex> lock(this->queue_mutex);

                // WILL WAIT FOREVER!!!
                this->condition.wait(lock,
                            [this]{ return this->stop || !this->tasks.empty(); });

```
