### PR TITLE
Flexible size thread pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A simple C++11 Thread Pool implementation.
 
 Basic usage:
 ```c++
-// create thread pool with 4 worker threads
-ThreadPool pool(4);
+// create thread pool
+ThreadPool pool;
 
 // enqueue and store future
 auto result = pool.enqueue([](int answer) { return answer; }, 42);

--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -13,12 +13,15 @@
 
 class ThreadPool {
 public:
-    ThreadPool(size_t);
+    ThreadPool();
     template<class F, class... Args>
     auto enqueue(F&& f, Args&&... args) 
         -> std::future<typename std::result_of<F(Args...)>::type>;
-    ~ThreadPool();
+    ~ThreadPool() noexcept;
 private:
+    void work();
+    void recycle();
+
     // need to keep track of threads so we can join them
     std::vector< std::thread > workers;
     // the task queue
@@ -28,34 +31,22 @@ private:
     std::mutex queue_mutex;
     std::condition_variable condition;
     bool stop;
+    int waiters;
+
+    // for recycle idle threads
+    static thread_local bool working;
+    std::atomic< int > maxIdle;
+    std::thread monitor;
 };
+
+thread_local bool ThreadPool::working = true;
  
-// the constructor just launches some amount of workers
-inline ThreadPool::ThreadPool(size_t threads)
-    :   stop(false)
+// the constructor just launches monitor thread
+inline ThreadPool::ThreadPool()
+    :   stop(false), waiters(0)
 {
-    for(size_t i = 0;i<threads;++i)
-        workers.emplace_back(
-            [this]
-            {
-                for(;;)
-                {
-                    std::function<void()> task;
-
-                    {
-                        std::unique_lock<std::mutex> lock(this->queue_mutex);
-                        this->condition.wait(lock,
-                            [this]{ return this->stop || !this->tasks.empty(); });
-                        if(this->stop && this->tasks.empty())
-                            return;
-                        task = std::move(this->tasks.front());
-                        this->tasks.pop();
-                    }
-
-                    task();
-                }
-            }
-        );
+    maxIdle = std::max< int >(1, static_cast<int>(std::thread::hardware_concurrency()));
+    monitor = std::thread([this]() { this->recycle(); } );
 }
 
 // add new work item to the pool
@@ -78,21 +69,78 @@ auto ThreadPool::enqueue(F&& f, Args&&... args)
             throw std::runtime_error("enqueue on stopped ThreadPool");
 
         tasks.emplace([task](){ (*task)(); });
+
+        // if there is no idle thread, create one, do not let this task wait
+        if (waiters == 0)
+        {
+            std::thread  t([this]() { this->work(); } );
+            workers.push_back(std::move(t));
+        }
     }
     condition.notify_one();
     return res;
 }
 
 // the destructor joins all threads
-inline ThreadPool::~ThreadPool()
+inline ThreadPool::~ThreadPool() noexcept
 {
     {
         std::unique_lock<std::mutex> lock(queue_mutex);
         stop = true;
     }
     condition.notify_all();
-    for(std::thread &worker: workers)
+    for(auto& worker: workers)
         worker.join();
+
+    monitor.join();
+}
+
+inline void ThreadPool::work() 
+{
+    working = true;
+
+    while (working)
+    {
+        std::function<void()> task;
+        
+        {
+            std::unique_lock<std::mutex> lock(this->queue_mutex);
+
+            ++ waiters; // incr waiter count
+            this->condition.wait(lock,
+                [this]{ return this->stop || !this->tasks.empty(); });
+            --  waiters; // decr waiter count
+
+            if(this->stop && this->tasks.empty())
+                return;
+            task = std::move(this->tasks.front());
+            this->tasks.pop();
+        }
+
+        task();
+    }
+
+    // if reach here, this thread is recycled by monitor thread
+}
+
+inline void ThreadPool::recycle() 
+{
+    while (!stop)
+    {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        
+        std::unique_lock<std::mutex> lock(this->queue_mutex);
+        if (stop)
+            return;
+        
+        auto nw = waiters;
+        while (nw -- > maxIdle)
+        {
+            // the thread which fetch this task item will exit
+            tasks.emplace([this]() { working = false; });
+            condition.notify_one();
+        }
+    }
 }
 
 #endif

--- a/example.cpp
+++ b/example.cpp
@@ -7,7 +7,7 @@
 int main()
 {
     
-    ThreadPool pool(4);
+    ThreadPool pool; // no need set pool size
     std::vector< std::future<int> > results;
 
     for(int i = 0; i < 8; ++i) {


### PR DESCRIPTION
Thread is created on demand, not when enter main function, and a monitor thread will recycle redundant idle threads.

I modified the worker thread routine,  use a thread local working flag to stop worker thread.
The working flag is like this:

``` c++
static thread_local bool working;
```

If monitor thread detects redundant idle thread, it will enqueue a task item like this: 

``` c++
tasks.emplace([this]() { working = false; });
```

Then a idle thread will take it , and stop its loop.
