### PR TITLE
Replacing `std::result_of` with `decltype`

### DIFF
--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -16,7 +16,7 @@ public:
     ThreadPool(size_t);
     template<class F, class... Args>
     auto enqueue(F&& f, Args&&... args) 
-        -> std::future<typename std::result_of<F(Args...)>::type>;
+        -> std::future<decltype(f(args...))>;
     ~ThreadPool();
 private:
     // need to keep track of threads so we can join them
@@ -61,9 +61,9 @@ inline ThreadPool::ThreadPool(size_t threads)
 // add new work item to the pool
 template<class F, class... Args>
 auto ThreadPool::enqueue(F&& f, Args&&... args) 
-    -> std::future<typename std::result_of<F(Args...)>::type>
+    -> std::future<decltype(f(args...))>
 {
-    using return_type = typename std::result_of<F(Args...)>::type;
+    using return_type = decltype(f(args...));
 
     auto task = std::make_shared< std::packaged_task<return_type()> >(
             std::bind(std::forward<F>(f), std::forward<Args>(args)...)


### PR DESCRIPTION
result_of and its helper type result_of_t are deprecated as of C++17