### PR TITLE
fix: should use lock_guard

### DIFF
--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -71,7 +71,7 @@ auto ThreadPool::enqueue(F&& f, Args&&... args)
         
     std::future<return_type> res = task->get_future();
     {
-        std::unique_lock<std::mutex> lock(queue_mutex);
+        std::lock_guard<std::mutex> lg(queue_mutex);
 
         // don't allow enqueueing after stopping the pool
         if(stop)
@@ -87,7 +87,7 @@ auto ThreadPool::enqueue(F&& f, Args&&... args)
 inline ThreadPool::~ThreadPool()
 {
     {
-        std::unique_lock<std::mutex> lock(queue_mutex);
+        std::lock_guard<std::mutex> lg(queue_mutex);
         stop = true;
     }
     condition.notify_all();


### PR DESCRIPTION
These two places do not serve as locks. You should use std:: lock_ guard