### PR TITLE
Replace deprecated functions on -std=c++17

### DIFF
--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -15,21 +15,25 @@ class ThreadPool {
 public:
     ThreadPool(size_t);
     template<class F, class... Args>
-    auto enqueue(F&& f, Args&&... args) 
+    auto enqueue(F&& f, Args&&... args)
+#if __cplusplus >= 201703L
+        -> std::future<typename std::invoke_result<F, Args...>::type>;
+#else
         -> std::future<typename std::result_of<F(Args...)>::type>;
+#endif // __cplusplus >= 201703L
     ~ThreadPool();
 private:
     // need to keep track of threads so we can join them
     std::vector< std::thread > workers;
     // the task queue
     std::queue< std::function<void()> > tasks;
-    
+
     // synchronization
     std::mutex queue_mutex;
     std::condition_variable condition;
     bool stop;
 };
- 
+
 // the constructor just launches some amount of workers
 inline ThreadPool::ThreadPool(size_t threads)
     :   stop(false)
@@ -60,15 +64,23 @@ inline ThreadPool::ThreadPool(size_t threads)
 
 // add new work item to the pool
 template<class F, class... Args>
-auto ThreadPool::enqueue(F&& f, Args&&... args) 
-    -> std::future<typename std::result_of<F(Args...)>::type>
+auto ThreadPool::enqueue(F&& f, Args&&... args)
+#if __cplusplus >= 201703L
+        -> std::future<typename std::invoke_result<F, Args...>::type>
+#else
+        -> std::future<typename std::result_of<F(Args...)>::type>
+#endif // __cplusplus >= 201703L
 {
+#if __cplusplus >= 201703L
+    using return_type = typename std::invoke_result<F, Args...>::type;
+#else
     using return_type = typename std::result_of<F(Args...)>::type;
+#endif // __cplusplus >= 201703L
 
     auto task = std::make_shared< std::packaged_task<return_type()> >(
             std::bind(std::forward<F>(f), std::forward<Args>(args)...)
         );
-        
+
     std::future<return_type> res = task->get_future();
     {
         std::unique_lock<std::mutex> lock(queue_mutex);


### PR DESCRIPTION
`std::result_of<T>` is deprecated, Since C++17

std::result_of<T> -> `std::invoke_result<T, Args...>`
